### PR TITLE
Fix for kernel version 6.5, added extra documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ git clone https://github.com/roadrunner2/macbook12-spi-driver.git /usr/src/apple
 dkms install -m applespi -v 0.1
 ```
 
+If after reboot the touchbar still doesn't light up, try the following:
+
+1. Test if motprobe command is successful (exit code 0)
+```
+sudo modprobe intel_lpss_pci spi_pxa2xx_platform applespi apple-ib-tb
+
+```
+2. If so, rebind USB drivers:
+```
+echo '1-3' | sudo tee /sys/bus/usb/drivers/usb/unbind
+echo '1-3' | sudo tee /sys/bus/usb/drivers/usb/bind
+```
+
 Akmods module (RPM Fusion / Red Hat & co):
 ------------------------------------------
 You can build the akmod package from this repository:

--- a/apple-ibridge.c
+++ b/apple-ibridge.c
@@ -843,13 +843,11 @@ static int appleib_probe(struct acpi_device *acpi)
 	return 0;
 }
 
-static int appleib_remove(struct acpi_device *acpi)
+static void appleib_remove(struct acpi_device *acpi)
 {
 	struct appleib_device *ib_dev = acpi_driver_data(acpi);
 
 	hid_unregister_driver(&ib_dev->ib_driver);
-
-	return 0;
 }
 
 static int appleib_suspend(struct device *dev)


### PR DESCRIPTION
The original fork does not compile against Kernel version 6.5.0-26-generic (Ubuntu 22.04.4 LTS). After fixing the C - code, it compiles, but the touch bar only lit up after rebinding the USB driver (MacBook Pro A1706 mid-2017).

Both the fix for the C - code and the extra commands I had to run are contained in this commit.